### PR TITLE
Replace HTML non-breaking space entities with the char code for SVG XML

### DIFF
--- a/app/scripts/tools/text.js
+++ b/app/scripts/tools/text.js
@@ -346,6 +346,7 @@ TextTool.prototype._saveText = function () {
 				'</foreignObject>' +
 			'</svg>';
 		svgData = svgData.replace(/<br>/g, '<br />'); // XML requires self-closing tags be closed, but HTML5 does not.
+		svgData = svgData.replace(/&nbsp;/g, '&#xa0;'); // HTML non-breaking space entity is not defined in XML, so reference the char code directly.
 		svgData = svgData.replace(/#/g, '%23'); // Escape hash for data URL.
 		
 		var svgImage = new Image(),


### PR DESCRIPTION
This fixes non-breaking spaces preventing text tool rasterizing text and closes #140.