### PR TITLE
Fix incorrect tool keyboard shortcut hints

### DIFF
--- a/app/partials/dialogs/keyboard.html
+++ b/app/partials/dialogs/keyboard.html
@@ -119,6 +119,34 @@
 		<td><strong>Ctrl+D</strong></td>
 		<td>Duplicate selection</td>
 	</tr>
+	<tr>
+		<td><strong>Ctrl+X</strong></td>
+		<td>Cut selection</td>
+	</tr>
+	<tr>
+		<td><strong>Ctrl+C</strong></td>
+		<td>Copy selection</td>
+	</tr>
+	<tr>
+		<td><strong>Ctrl+V</strong></td>
+		<td>Paste selection</td>
+	</tr>
+	<tr>
+		<td><strong>Ctrl+B</strong></td>
+		<td>Bold text</td>
+	</tr>
+	<tr>
+		<td><strong>Ctrl+I</strong></td>
+		<td>Italicize text</td>
+	</tr>
+	<tr>
+		<td><strong>Ctrl+U</strong></td>
+		<td>Underline text</td>
+	</tr>
+	<tr>
+		<td style="padding-right: 0.5em; /* Add a little extra padding on the longest line. */"><strong>Alt+Shift+5</strong></td>
+		<td>Strike text</td>
+	</tr>
 	<tr><td colspan="2">&nbsp;</td></tr>
 	<tr>
 		<th colspan="2">App actions</th>

--- a/app/partials/dialogs/keyboard.html
+++ b/app/partials/dialogs/keyboard.html
@@ -72,12 +72,16 @@
 		<td>Selection</td>
 	</tr>
 	<tr>
+		<td><strong>F</strong></td>
+		<td>Freeform selection</td>
+	</tr>
+	<tr>
 		<td><strong>E</strong></td>
 		<td>Eraser</td>
 	</tr>
 	<tr>
-		<td><strong>F</strong></td>
-		<td>Flood fill</td>
+		<td><strong>K</strong></td>
+		<td>Flood fill (paint bucket)</td>
 	</tr>
 	<tr>
 		<td><strong>I</strong></td>

--- a/app/partials/toolbar/tools.html
+++ b/app/partials/toolbar/tools.html
@@ -55,7 +55,7 @@
 		</svg>
 	</label><!--
 	--><input type="radio" name="tool" value="freeformSelection" id="freeformSelectionTool" /><!--
-	--><label role="button" for="freeformSelectionTool" title="Freeform selection">
+	--><label role="button" for="freeformSelectionTool" title="Freeform selection (F)">
 		<svg role="img">
 			<use xlink:href="images/icons/freeform_select.svg#icon" href="images/icons/freeform_select.svg#icon"></use>
 		</svg>
@@ -67,7 +67,7 @@
 		</svg>
 	</label><!--
 	--><input type="radio" name="tool" value="floodFill" id="floodFillTool" /><!--
-	--><label role="button" for="floodFillTool" title="Flood fill (F)">
+	--><label role="button" for="floodFillTool" title="Flood fill (K)">
 		<svg role="img">
 			<use xlink:href="images/icons/paint_bucket.svg#icon" href="images/icons/paint_bucket.svg#icon"></use>
 		</svg>


### PR DESCRIPTION
This closes #146.  It also adds keyboard shortcut help for new selection and text tool actions.